### PR TITLE
Use nuget for rhino libs

### DIFF
--- a/ghgl.csproj
+++ b/ghgl.csproj
@@ -34,30 +34,27 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eto">
-      <HintPath>C:\Program Files\Rhino 6\System\Eto.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Eto, Version=2.3.6591.18824, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
+      <HintPath>packages\RhinoCommon.6.0.18016.23451\lib\net45\Eto.dll</HintPath>
     </Reference>
-    <Reference Include="Eto.Wpf">
-      <HintPath>C:\Program Files\Rhino 6\System\Eto.Wpf.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Eto.Wpf, Version=2.3.6591.18824, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
+      <HintPath>packages\RhinoWindows.6.0.18016.23451-test3\lib\net45\Eto.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="GH_IO">
-      <HintPath>C:\Program Files\Rhino 6\Plug-ins\Grasshopper\GH_IO.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="GH_IO, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=6a29997d2e6b4f97, processorArchitecture=MSIL">
+      <HintPath>packages\Grasshopper.6.0.18016.23451\lib\net45\GH_IO.dll</HintPath>
     </Reference>
-    <Reference Include="Grasshopper">
-      <HintPath>C:\Program Files\Rhino 6\Plug-ins\Grasshopper\Grasshopper.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Grasshopper, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=dda4f5ec2cd80803, processorArchitecture=MSIL">
+      <HintPath>packages\Grasshopper.6.0.18016.23451\lib\net45\Grasshopper.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework" />
-    <Reference Include="Rhino.UI">
-      <HintPath>C:\Program Files\Rhino 6\System\Rhino.UI.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Rhino.UI, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
+      <HintPath>packages\RhinoCommon.6.0.18016.23451\lib\net45\Rhino.UI.dll</HintPath>
     </Reference>
-    <Reference Include="RhinoCommon">
-      <HintPath>C:\Program Files\Rhino 6\System\RhinoCommon.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="RhinoCommon, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
+      <HintPath>packages\RhinoCommon.6.0.18016.23451\lib\net45\RhinoCommon.dll</HintPath>
+    </Reference>
+    <Reference Include="RhinoWindows, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
+      <HintPath>packages\RhinoWindows.6.0.18016.23451-test3\lib\net45\RhinoWindows.dll</HintPath>
     </Reference>
     <Reference Include="ScintillaNET, Version=3.6.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll</HintPath>

--- a/packages.config
+++ b/packages.config
@@ -3,4 +3,5 @@
   <package id="Grasshopper" version="6.0.18016.23451" targetFramework="net45" />
   <package id="jacobslusser.ScintillaNET" version="3.6.3" targetFramework="net45" />
   <package id="RhinoCommon" version="6.0.18016.23451" targetFramework="net45" />
+  <package id="RhinoWindows" version="6.0.18016.23451-test3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
RhinoCommon and Grasshopper (6.0) packages already present. Switches
refs over to the assemblies provided by those packages. Adds a new
package for RhinoWindows which includes RhinoWindows.dll and
Eto.Wpf.dll.