### PR TITLE
Add keywords to manifest.yml

### DIFF
--- a/dist/manifest.yml
+++ b/dist/manifest.yml
@@ -5,5 +5,7 @@ authors:
 - Robert McNeel & Associates
 description: OpenGL shader support in Grasshopper
 url: https://github.com/mcneel/ghgl
-secret:
-  id: 835c3e29-712f-4585-9d0b-8192359ad167
+keywords:
+- guid:835c3e29-712f-4585-9d0b-8192359ad167
+- opengl
+- shader


### PR DESCRIPTION
* Removes the deprecated `secret.id` field
* Requires a Rhino built after 24th June 2020, otherwise the `yak build` command will strip out the keywords